### PR TITLE
Use fully loaded node entities in routes starting with /node/{node}

### DIFF
--- a/embargoes.routing.yml
+++ b/embargoes.routing.yml
@@ -41,6 +41,10 @@ embargoes.node.embargo:
     _title: 'Edit Embargo'
   requirements:
     _permission: 'manage embargoes'
+  options:
+    parameters:
+      node:
+        type: entity:node
 
 embargoes.ip_access_denied:
   path: '/embargoes/ip-access-denied'

--- a/embargoes.routing.yml
+++ b/embargoes.routing.yml
@@ -29,6 +29,10 @@ embargoes.node.embargoes:
     _title: 'View Embargoes'
   requirements:
     _permission: 'manage embargoes'
+  options:
+    parameters:
+      node:
+        type: entity:node
 
 embargoes.node.embargo:
   path: '/node/{node}/embargoes/{embargo_id}'

--- a/src/Controller/EmbargoesNodeEmbargoesController.php
+++ b/src/Controller/EmbargoesNodeEmbargoesController.php
@@ -4,15 +4,16 @@ namespace Drupal\embargoes\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\Markup;
+use Drupal\node\NodeInterface;
 
 /**
  * Class EmbargoesLogController.
  */
 class EmbargoesNodeEmbargoesController extends ControllerBase {
 
-  public function showEmbargoes($node = NULL) {
+  public function showEmbargoes(NodeInterface $node = NULL) {
 
-    $embargo_ids = \Drupal::service('embargoes.embargoes')->getAllEmbargoesByNids(array($node));
+    $embargo_ids = \Drupal::service('embargoes.embargoes')->getAllEmbargoesByNids(array($node->id()));
     if (empty($embargo_ids)) {
       $markup['embargoes'] = [
         '#type' => 'markup',
@@ -62,7 +63,7 @@ class EmbargoesNodeEmbargoesController extends ControllerBase {
           'exempt_ips' => $ip_range_formatted,
           'exempt_users' => $formatted_exempt_users_row,
           'additional_emails' => $formatted_emails,
-          'edit' => Markup::create("<a href='/node/{$node}/embargoes/{$embargo_id}'>Edit</a><br><a href='/admin/config/content/embargoes/settings/embargoes/{$embargo_id}/delete'>Delete</a>"),
+          'edit' => Markup::create("<a href='/node/{$node->id()}/embargoes/{$embargo_id}'>Edit</a><br><a href='/admin/config/content/embargoes/settings/embargoes/{$embargo_id}/delete'>Delete</a>"),
         ];
         array_push($rows, $row);
       }
@@ -76,7 +77,7 @@ class EmbargoesNodeEmbargoesController extends ControllerBase {
 
     $markup['add'] = [
       '#type' => 'markup',
-      '#markup' => Markup::create("<p><a href='/node/{$node}/embargoes/add'>Add Embargo</a></p>"),
+      '#markup' => Markup::create("<p><a href='/node/{$node->id()}/embargoes/add'>Add Embargo</a></p>"),
     ];
 
     return [

--- a/src/Form/EmbargoesNodeEmbargoesForm.php
+++ b/src/Form/EmbargoesNodeEmbargoesForm.php
@@ -35,7 +35,7 @@ class EmbargoesNodeEmbargoesForm extends FormBase {
 
     $form['embargoed_node'] = array(
       '#type' => 'hidden',
-      '#value' => $node,
+      '#value' => $node->id(),
     );
 
     $form['embargo_type'] = array(

--- a/src/Form/EmbargoesNodeEmbargoesForm.php
+++ b/src/Form/EmbargoesNodeEmbargoesForm.php
@@ -4,6 +4,7 @@ namespace Drupal\embargoes\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Class EmbargoesNodeEmbargoesForm.
@@ -20,7 +21,7 @@ class EmbargoesNodeEmbargoesForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $node = NULL, $embargo_id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, NodeInterface $node = NULL, $embargo_id = NULL) {
 
 
     if ($embargo_id != "add") {
@@ -34,7 +35,7 @@ class EmbargoesNodeEmbargoesForm extends FormBase {
 
     $form['embargoed_node'] = array(
       '#type' => 'hidden',
-      '#value' => $node,
+      '#value' => $node->id(),
     );
 
     $form['embargo_type'] = array(

--- a/src/Form/EmbargoesNodeEmbargoesForm.php
+++ b/src/Form/EmbargoesNodeEmbargoesForm.php
@@ -35,7 +35,7 @@ class EmbargoesNodeEmbargoesForm extends FormBase {
 
     $form['embargoed_node'] = array(
       '#type' => 'hidden',
-      '#value' => $node->id(),
+      '#value' => $node,
     );
 
     $form['embargo_type'] = array(


### PR DESCRIPTION
Passing in the node ID as a string in routes is causing issues with modules that expect routes that are part of `/node/{node}` to have that `{node}` be a loaded node entity.

This can be demonstrated (and was initially observed) by enabling the [Permissions by Term](https://www.drupal.org/project/permissions_by_term) module, which [grabs the node out of the route](https://git.drupalcode.org/project/permissions_by_term/-/blob/5c193d630362fca724fe9a618ac6d82919e316d9/permissions_by_term.module#L226-227) to determine access. Since the `EmbargoesNodeEmbargoesController` gets a string instead of an entity object, the node entity isn't available from the route parameters, and the call to `$node->id()` fails.

I'm not sure I can dig up any standards describing this as being a hard requirement, but since `/node/{node}` comes from the `node` module itself, it would make sense to align any new sub-routes with how the node module does things. It's also worth mentioning that the `{node}` that gets passed into the `embargoes.node.embargo` route is already a `Drupal\node\Entity\Node` object despite not having been specified, which does reinforce that this behaviour is expected.

This PR is to update the `embargoes.node.embargoes` route to use a node entity, to accept that node entity on the other end, and to update the `EmbargoesNodeEmbargoesForm` to document what's being passed in.