### PR TITLE
Use of database column 'user' fails on PostgreSQL

### DIFF
--- a/embargoes.install
+++ b/embargoes.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Database\Database;
+
 /**
 * @file
 * Install, update and uninstall functions for the embargoes module.
@@ -30,7 +32,7 @@ function embargoes_schema() {
         'type' => 'int',
         'not null' => TRUE,
       ],
-      'user' => [
+      'uid' => [
         'type' => 'int',
         'not null' => TRUE,
       ],
@@ -43,4 +45,58 @@ function embargoes_schema() {
     'primary key' => ['id'],
   ];
   return $schema;
+}
+
+/**
+ * Update the 'user' column to be called 'uid'.
+ */
+function embargoes_update_8001(&$sandbox) {
+  $conn = Database::getConnection();
+
+  // Add the new field. Initially nullable; this will be changed once all fields
+  // have content.
+  $conn->schema()->addField('embargoes_log', 'uid', [
+    'type' => 'int',
+  ]);
+
+  // Migrate current data.
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['current'] = 0;
+    $sandbox['total'] = $conn
+      ->select('embargoes_log', 'el')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    if (empty($sandbox['total'])) {
+      $sandbox['#finished'] = 1;
+      $conn->schema()->changeField('embargoes_log', 'uid', 'uid', ['not null' => TRUE]);
+      $conn->schema()->dropField('embargoes_log', 'user');
+      return t('No logs to update');
+    }
+  }
+  $logs = $conn
+    ->select('embargoes_log', 'el')
+    ->fields('el', ['id', 'user'])
+    ->condition('id', $sandbox['current'], '>')
+    ->range(0, 20)
+    ->orderBy('id', 'ASC')
+    ->execute();
+  foreach ($logs as $log) {
+    $conn
+      ->update('embargoes_log')
+      ->fields(['uid' => $log->user])
+      ->condition('id', $log->id)
+      ->execute();
+    $sandbox['#message'] = t('Updated log ID: %id', ['%id' => $log->id]);
+    $sandbox['progress']++;
+  }
+
+  // Finish check.
+  $sandbox['#finished'] = empty($sandbox['total']) ? 1 : floor($sandbox['progress'] / $sandbox['max']);
+  if ($sandbox['#finished']) {
+    $conn->schema()->changeField('embargoes_log', 'uid', 'uid', ['not null' => TRUE]);
+    $conn->schema()->dropField('embargoes_log', 'user');
+    return t('Updated %count logs', ['%count' => $sandbox['progress']]);
+  }
 }

--- a/embargoes.install
+++ b/embargoes.install
@@ -51,52 +51,8 @@ function embargoes_schema() {
  * Update the 'user' column to be called 'uid'.
  */
 function embargoes_update_8001(&$sandbox) {
-  $conn = Database::getConnection();
-
-  // Add the new field. Initially nullable; this will be changed once all fields
-  // have content.
-  $conn->schema()->addField('embargoes_log', 'uid', [
+  Database::getConnection()->schema()->changeField('embargoes_log', 'user', 'uid', [
+    'not null' => TRUE,
     'type' => 'int',
   ]);
-
-  // Migrate current data.
-  if (!isset($sandbox['progress'])) {
-    $sandbox['progress'] = 0;
-    $sandbox['current'] = 0;
-    $sandbox['total'] = $conn
-      ->select('embargoes_log', 'el')
-      ->countQuery()
-      ->execute()
-      ->fetchField();
-    if (empty($sandbox['total'])) {
-      $sandbox['#finished'] = 1;
-      $conn->schema()->changeField('embargoes_log', 'uid', 'uid', ['not null' => TRUE]);
-      $conn->schema()->dropField('embargoes_log', 'user');
-      return t('No logs to update');
-    }
-  }
-  $logs = $conn
-    ->select('embargoes_log', 'el')
-    ->fields('el', ['id', 'user'])
-    ->condition('id', $sandbox['current'], '>')
-    ->range(0, 20)
-    ->orderBy('id', 'ASC')
-    ->execute();
-  foreach ($logs as $log) {
-    $conn
-      ->update('embargoes_log')
-      ->fields(['uid' => $log->user])
-      ->condition('id', $log->id)
-      ->execute();
-    $sandbox['#message'] = t('Updated log ID: %id', ['%id' => $log->id]);
-    $sandbox['progress']++;
-  }
-
-  // Finish check.
-  $sandbox['#finished'] = empty($sandbox['total']) ? 1 : floor($sandbox['progress'] / $sandbox['max']);
-  if ($sandbox['#finished']) {
-    $conn->schema()->changeField('embargoes_log', 'uid', 'uid', ['not null' => TRUE]);
-    $conn->schema()->dropField('embargoes_log', 'user');
-    return t('Updated %count logs', ['%count' => $sandbox['progress']]);
-  }
 }

--- a/src/Controller/EmbargoesLogController.php
+++ b/src/Controller/EmbargoesLogController.php
@@ -18,7 +18,7 @@ class EmbargoesLogController extends ControllerBase {
     foreach ($result as $record) {
       $formatted_time = date('c', $record->time);
       $node_title = \Drupal::entityTypeManager()->getStorage('node')->load($record->node)->get('title')->value;
-      $username = \Drupal\user\Entity\User::load($record->user)->getUsername();
+      $username = \Drupal\user\Entity\User::load($record->uid)->getUsername();
       if ($record->action == "deleted") {
         $embargo_formatted = Markup::create("<span style='text-decoration:line-through;'>{$record->embargo}</span>");
       }
@@ -32,7 +32,7 @@ class EmbargoesLogController extends ControllerBase {
         'time' => $formatted_time,
         'action' => ucfirst($record->action),
         'node' => Markup::create("<a href='/node/{$record->node}'>$node_title</a>"),
-        'user' =>  Markup::create("<a href='/user/{$record->user}'>$username</a>"),
+        'user' =>  Markup::create("<a href='/user/{$record->uid}'>$username</a>"),
       ];
       array_push($formatted_log, $row);
     }

--- a/src/EmbargoesLogService.php
+++ b/src/EmbargoesLogService.php
@@ -17,7 +17,7 @@ class EmbargoesLogService implements EmbargoesLogServiceInterface {
   public function logEmbargoEvent($values) {
     $time = time();
     $database = \Drupal::database();
-    $result = $database->query("INSERT INTO {embargoes_log} (time, action, node, user, embargo) VALUES ('{$time}', '{$values['action']}', '{$values['node']}', '{$values['user']}','{$values['embargo_id']}');");
+    $result = $database->query("INSERT INTO {embargoes_log} (time, action, node, uid, embargo) VALUES ('{$time}', '{$values['action']}', '{$values['node']}', '{$values['user']}','{$values['embargo_id']}');");
     return $result;
   }
 

--- a/src/EmbargoesLogService.php
+++ b/src/EmbargoesLogService.php
@@ -15,10 +15,11 @@ class EmbargoesLogService implements EmbargoesLogServiceInterface {
   }
 
   public function logEmbargoEvent($values) {
-    $time = time();
-    $database = \Drupal::database();
-    $result = $database->query("INSERT INTO {embargoes_log} (time, action, node, uid, embargo) VALUES ('{$time}', '{$values['action']}', '{$values['node']}', '{$values['user']}','{$values['embargo_id']}');");
-    return $result;
+    $conn = \Drupal::database()->getConnection();
+    $values['time'] = time();
+    return $conn->insert('embargoes_log')
+      ->fields($values)
+      ->execute();
   }
 
 }

--- a/src/Form/EmbargoesEmbargoEntityDeleteForm.php
+++ b/src/Form/EmbargoesEmbargoEntityDeleteForm.php
@@ -38,7 +38,7 @@ class EmbargoesEmbargoEntityDeleteForm extends EntityConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $log_values['node'] = $this->entity->getEmbargoedNode();
-    $log_values['user'] = \Drupal::currentUser()->id();
+    $log_values['uid'] = \Drupal::currentUser()->id();
     $log_values['embargo_id'] = $this->entity->id();
     $log_values['action'] = 'deleted';
     \Drupal::messenger()->addMessage("Your embargo has been {$log_values['action']}.");

--- a/src/Form/EmbargoesEmbargoEntityForm.php
+++ b/src/Form/EmbargoesEmbargoEntityForm.php
@@ -118,7 +118,7 @@ class EmbargoesEmbargoEntityForm extends EntityForm {
     $status = $embargo->save();
 
     $log_values['node'] = $embargo->getEmbargoedNode();
-    $log_values['user'] = \Drupal::currentUser()->id();
+    $log_values['uid'] = \Drupal::currentUser()->id();
     $log_values['embargo_id'] = $embargo->id();
 
     if ($status == SAVED_NEW) {

--- a/src/Form/EmbargoesNodeEmbargoesForm.php
+++ b/src/Form/EmbargoesNodeEmbargoesForm.php
@@ -155,7 +155,7 @@ class EmbargoesNodeEmbargoesForm extends FormBase {
     $embargo->save();
 
     $log_values['node'] = $embargo->getEmbargoedNode();
-    $log_values['user'] = \Drupal::currentUser()->id();
+    $log_values['uid'] = \Drupal::currentUser()->id();
     $log_values['embargo_id'] = $embargo->id();
 
     if ($embargo_id == 'add') {


### PR DESCRIPTION
Having some trouble getting this up and running on a box using PostgreSQL instead of MySQL; the use of `user` as a column name trips things up since this is a reserved word.

Actually, it seems to be a reserved word in MySQL as well, just that MySQL appears to not care for whatever reason ... probably not ideal behaviour out of it, but that's neither here nor there :/

Given that avoidance of reserved words is [part of coding standards anyhow](https://www.drupal.org/docs/develop/standards/sql-coding-conventions#reserved-words), changing this would seem necessary.

This PR includes the change to the column name and usages to `uid`, which seems more the standard, as well as an update hook to migrate existing logs over.