### PR TITLE
Curb attempt to iterate over NULL from getParentNidsOfFileEntity()

### DIFF
--- a/src/EmbargoesEmbargoesService.php
+++ b/src/EmbargoesEmbargoesService.php
@@ -167,12 +167,12 @@ namespace Drupal\embargoes;
   public function getParentNidsOfFileEntity($file) {
     $relationships = file_get_file_references($file);
     if (!$relationships) {
-      $nids = NULL;
+      $nids = [];
     }
     else {
       foreach ($relationships as $relationship) {
         if (!$relationship) {
-          $nids = NULL;
+          $nids = [];
         }
         else {
           foreach ($relationship as $key => $value) {

--- a/src/Entity/EmbargoesEmbargoEntity.php
+++ b/src/Entity/EmbargoesEmbargoEntity.php
@@ -52,11 +52,11 @@ class EmbargoesEmbargoEntity extends ConfigEntityBase implements EmbargoesEmbarg
 
   protected $expiration_date;
 
-  protected $exempt_ips;
+  protected $exempt_ips = [];
 
-  protected $exempt_users;
+  protected $exempt_users = [];
 
-  protected $additional_emails;
+  protected $additional_emails = [];
 
   protected $embargoed_node;
 


### PR DESCRIPTION
`\Drupal\embargoes\EmbargoesEmbargoesService\getParentNidsOfFileEntity()` returns either `NULL` or an array depending on found relationships. Both times it's being used in practice in `embargoes.module`, the results are being passed to `getActiveEmbargoesByNids()`, which passes them through to `getCurrentEmbargoesByNids()`, which passes them through to `getAllEmbargoesByNids()`, which attempts to iterate over them as an array. If the file entity doesn't have any parents, iterating over `NULL` causes an error to be thrown.

It's hard to tell the direction to go in here (could do a null check in the .module), but I'm thinking it's perhaps reasonable to enforce that `getParentNidsOfFileEntity()` returns an array that may be empty if there are no such node IDs or aren't accessible.